### PR TITLE
feature: improve volume change logic in mute

### DIFF
--- a/kb1k_owntone.py
+++ b/kb1k_owntone.py
@@ -98,7 +98,7 @@ async def event_handler(queue: asyncio.Queue):
             if not path:
                 continue
             async with httpx.AsyncClient() as client:
-                r = await client.put(f"{API_SCHEMA}://{API_HOST}{path}")
+                _ = await client.put(f"{API_SCHEMA}://{API_HOST}{path}")
             (
                 _state,
                 _volume,


### PR DESCRIPTION
ミュート中に、ダイヤル操作で `volDown` または `volUp` のイベントが発生した際に、
既存のコードでは、ミュート中の（仮の）ボリュームである `0` からの変化で操作していたが、
ミュート中に保持している、ミュート前のボリュームに対する操作に変更するようにした。