### PR TITLE
add '.flake8'

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203


### PR DESCRIPTION
1行辺りの文字数制限を、 `black` の `88` 文字にするため、
`flake8` の設定を変更するためのファイルを追加。